### PR TITLE
feat: add SQLite with sqlite-vec for vector embeddings

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,3 +25,6 @@ tauri = { version = "2.9.5", features = [] }
 tauri-plugin-log = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-shell = "2"
+rusqlite = { version = "0.31", features = ["bundled"] }
+sqlite-vec = "0.1"
+dirs = "5"

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -1,0 +1,64 @@
+use rusqlite::{Connection, Result};
+use sqlite_vec::sqlite3_vec_init;
+use std::fs;
+use std::path::PathBuf;
+
+fn get_database_path() -> PathBuf {
+    let home_dir = dirs::home_dir().expect("Could not find home directory");
+    let app_dir = home_dir.join(".smart-notes");
+
+    fs::create_dir_all(&app_dir).expect("Could not create app directory");
+
+    app_dir.join("notes.db")
+}
+
+pub fn init_database() -> Result<Connection> {
+    let db_path = get_database_path();
+    let conn = Connection::open(&db_path)?;
+
+    unsafe {
+        conn.load_extension_enable()?;
+        conn.load_extension(sqlite3_vec_init as *const (), None)?;
+        conn.load_extension_disable()?;
+    }
+
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS notes (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL,
+            content TEXT NOT NULL,
+            file_path TEXT,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        );
+
+        CREATE VIRTUAL TABLE IF NOT EXISTS note_embeddings USING vec0 (
+            note_id INTEGER PRIMARY KEY,
+            embedding FLOAT[384]
+        );
+
+        CREATE TRIGGER IF NOT EXISTS notes_updated_at
+        AFTER UPDATE ON notes
+        FOR EACH ROW
+        BEGIN
+            UPDATE notes SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id;
+        END;
+        "
+    )?;
+
+    log::info!("Database initialized at {:?}", db_path);
+
+    Ok(conn)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_init_database() {
+        let conn = init_database();
+        assert!(conn.is_ok());
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,5 @@
+mod database;
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -11,6 +13,12 @@ pub fn run() {
                         .build(),
                 )?;
             }
+
+            match database::init_database() {
+                Ok(_) => log::info!("Database initialized successfully"),
+                Err(e) => log::error!("Failed to initialize database: {}", e),
+            }
+
             Ok(())
         })
         .run(tauri::generate_context!())


### PR DESCRIPTION
- Add rusqlite, sqlite-vec, and dirs dependencies
- Create database module with init_database() function
- Create notes table for metadata storage
- Create note_embeddings virtual table (vec0) for 384-dim vectors
- Initialize database at app startup in ~/.smart-notes/notes.db
- Add trigger for automatic updated_at timestamp

Closes #2